### PR TITLE
Setting target with to outerwidth to match spacer

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -114,7 +114,7 @@
                 // not fill the rest of the page horizontally. Also, set its top
                 // to the margin top specified in the options.
                 target.css({
-                    'width' : target.width(),
+                    'width' : target.outerWidth(true),
                     'position' : 'fixed',
                     'top' : base.options.bottom == -1?getMarginTop():'',
                     'bottom' : base.options.bottom == -1?'':base.options.bottom


### PR DESCRIPTION
This fixed a bug I was seeing where elements would get smaller when scrolling but I'm not not sure if it's correct in all cases.
