### PR TITLE
Don't insert spacer if element is fixed.

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -296,7 +296,7 @@
             spacer = $('<div />');
 
             // Place the spacer right after the target element.
-            base.$el.after(spacer);
+            if (isUnfixed()) base.$el.after(spacer);
 
             // Reset the target element offsets when the window is resized, then
             // check to see if we need to fix or unfix the target element.


### PR DESCRIPTION
It's me again, I had to make this change for fixing an absolute positioned element. If I didn't do this then the layout would jump as the spacer was inserted because the element was never taking up space. I think. :)
