### PR TITLE
prevents malicious checkScroll() call after the plugin is removed from element (after remove.ScrollToFixed was triggered)

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -193,6 +193,7 @@
         // Checks to see if we need to do something based on new scroll position
         // of the page.
         function checkScroll() {
+            if (!$.isScrollToFixed(target)) return;
             var wasReset = isReset;
 
             // If resetScroll has not yet been called, call it. This only


### PR DESCRIPTION
Hello, it is nice to work on your plugin again )))

See the sample below. The problem this PR tries to solve is a correct removal of a plugin. Without the line the PR adds, after plugin is removed by `trigger('remove.ScrollToFixed')`, the `checkScroll` is called (I have one run in my sample) which causes additional malicious `setFixed()` call on elements which should stay on their "unfixed" original positions. This all seems strange, because needed `.unbind` calls are there (in `bind('remove.ScrollToFixed')`), but anyway I have exactly one call of `checkScroll` which makes markers "fixed" again.

``` html
<!DOCTYPE html>
<html>
<head>

  <meta charset='utf-8'>
  <title> *** ScrollToFixed with endless scroll ***</title>

  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js" type="text/javascript"></script>
  <script src="https://raw.github.com/stanislaw/ScrollToFixed/master/jquery-scrolltofixed.js" type="text/javascript"></script>
  <script src="https://raw.github.com/BorisMoore/jsrender/master/jsrender.js" type="text/javascript"></script>

  <style type="text/css">
    body {
      margin-top:10px;
    }

    .wrapper {
      width: 500px;
      margin: 0 auto;
    }

    .marker {
      position: absolute; // This is important
      margin: 0 auto;
      width: 200px;
      height: 98px;
      border: 3px dashed red;
      text-align: center;
      font-size: 20px;
    }

    .section {
      margin: 0;
      text-align: center;
      font-size: 40px;
      height: 800px;
      border: 3px #666 dashed;
    }
  </style>

  <script>
    $(function() {
      function addContainers() {
        var nextN = $('.marker-container').length + 1;
        var containers = []

        // Each container has 2 sections now
        for(var i = nextN; i <= nextN + 0; i++) {
          containers.push({ number: i})
        };

        $(".wrapper").html($(".wrapper").html() + $("#template").render(containers));
      }

      function registerMarkers() {
        var collection = $('.marker');

        $.each(collection, function(index, marker) {
          // The last element always does not have a limit
          if (index == collection.length - 1) {
            if ($.isScrollToFixed(marker)) $(marker).trigger('remove.ScrollToFixed');
            $(marker).scrollToFixed();
          } else {
            var nextMarker = $(collection[index + 1]);

            // Skip current, if it and the following one are already registered
            if ($.isScrollToFixed(marker) && $.isScrollToFixed(nextMarker)) return true;
            // On this stage we have all unregistered markers and the last registered one, which precedes the first unregistered marker.

            var nextMarkerC = nextMarker.parent(); // For offsets we rely on stable position of marker container

            $(marker).scrollToFixed({
              limit: nextMarkerC.offset().top - 100
            });
          }
        });
      }

      addContainers();
      registerMarkers();

      $(window).bind('scroll', function() {
        // If we reached the end of window
        if (document.body.scrollHeight - $(this).scrollTop() <= $(this).height()) {
          addContainers();
          registerMarkers();
        }
      });

      // <= 600 is a check for "responsive design"
      $(window).unbind('resize.scrollingDateMarkers').bind('resize.scrollingDateMarkers', function(evt) {
        var $collection = $('.marker');
        if ($(window).width() <= 600) {
          if ($.isScrollToFixed($collection)) $($collection).trigger('remove.ScrollToFixed');
        } else {
          if (!$.isScrollToFixed($collection)) registerMarkers;
        }
      });

    });
  </script>
</head>
<body>

  <script id="template" type="text/x-jsrender">
    <div class="marker-container">
      <div class="marker">Date {{>number}}</div>
    </div>
    <div class="section">One event</div>
    <div class="section">Another event</div>
  </script>

  <div class="wrapper"></div>
</body>
</html>
```
