### PR TITLE
Coherent top offset usage

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -25,7 +25,7 @@
         var position;
         var originalPosition;
 
-        var originalOffset;
+        var originalOffsetTop;
 
         // The offset top of the element when resetScroll was called. This is
         // used to determine if we have scrolled past the top of the element.
@@ -193,7 +193,7 @@
                     'width' : '',
                     'position' : originalPosition,
                     'left' : '',
-                    'top' : originalOffset.top,
+                    'top' : originalOffsetTop,
                     'margin-left' : ''
                 });
 
@@ -428,7 +428,7 @@
             position = target.css('position');
             originalPosition = target.css('position');
 
-            originalOffset = $.extend({}, target.offset());
+            originalOffsetTop = target.css('top');
 
             // Place the spacer right after the target element.
             if (isUnfixed()) base.$el.after(spacer);


### PR DESCRIPTION
I'm seeing some trouble when saving the element's (<form> one in my case) _top offset_ before fixing and then applying the same value as its _top CSS attribute_ when unfixing. Maybe I'm missing something but I can't figure out why you'd want to do that?

The problem I experienced was that when my element was unfixed, it got position:relative and top:xxx, which made it jump down a lot and essentially become invisible to the user. This fix takes care of that.
