### PR TITLE
Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "ScrollToFixed",
+  "version": "1.0.0",
+  "homepage": "http://bigspotteddog.github.io/ScrollToFixed/",
+  "description": "jQuery plugin used to fix elements on the page (top, bottom, anywhere); however, it still allows the element to continue to move left or right with the horizontal scroll.",
+  "main": "jquery-scrolltofixed.js",
+  "dependencies": {
+    "jquery": ">=1.6",
+  }
+  "keywords": [
+    "jQuery", "scroll", "fixed"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "bower_components",
+    "tests",
+    "test*.html"
+  ]
+}


### PR DESCRIPTION
Allows installation of the plugin trough [Bower](http://bower.io/).
Once this PR merged, a [Git tag](https://github.com/blog/1547-release-your-software) called "1.0.0" must be created to enable Bower support.
