### PR TITLE
Wrong use of semicolons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
   "description": "jQuery plugin used to fix elements on the page (top, bottom, anywhere); however, it still allows the element to continue to move left or right with the horizontal scroll.",
   "main": "jquery-scrolltofixed.js",
   "dependencies": {
-    "jquery": ">=1.6",
-  }
+    "jquery": ">=1.6"
+  },
   "keywords": [
     "jQuery", "scroll", "fixed"
   ],


### PR DESCRIPTION
bower install throw an error for unexpected token
