### PR TITLE
Set width to fix responsive, specially for Twitter bootstrap 3

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -141,6 +141,9 @@
                 }
                 if (!base.options.dontSetWidth){ cssOptions['width']=target.width(); };
 
+		//Set width to fix responsive, specially for Twitter bootstrap 3 
+		cssOptions['width']=target.outerWidth(true)+'px';
+                
                 target.css(cssOptions);
 
                 target.addClass('scroll-to-fixed-fixed');


### PR DESCRIPTION
I tried in Twitter Bootstrap to ScroollToFixed my some panel-heading on .row .col-md-12 .panel .panel-heading, also in .col-md-6, in the end on windows resize 480x600.
