### PR TITLE
Implement requestAnimationFrame

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -373,7 +373,7 @@
         }
 
         var windowScroll = function(event) {
-            checkScroll();
+            (!!window.requestAnimationFrame) ? requestAnimationFrame(checkScroll) : checkScroll();
         }
 
         // From: http://kangax.github.com/cft/#IS_POSITION_FIXED_SUPPORTED


### PR DESCRIPTION
Uses rAF if available.
Does not use autoprefixing, as it might already be implemented somewhere globally.
If shim/autoprefixer is needed in project, you should use solutions like [this.](http://stackoverflow.com/questions/5605588/how-to-use-requestanimationframe)
