### PR TITLE
Make setWidth work with border-box

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -147,7 +147,7 @@
                     'bottom' : base.options.bottom == -1?'':base.options.bottom,
                     'margin-left' : '0px'
                 }
-                if (!base.options.dontSetWidth){ cssOptions['width']=target.width(); };
+                if (!base.options.dontSetWidth){ cssOptions['width']=target.css('width'); };
 
                 target.css(cssOptions);
                 
@@ -178,7 +178,7 @@
               'margin-left' : '0px',
               'bottom' : ''
             }
-            if (!base.options.dontSetWidth){ cssOptions['width']=target.width(); };
+            if (!base.options.dontSetWidth){ cssOptions['width']=target.css('width'); };
 
             target.css(cssOptions);
 


### PR DESCRIPTION
`.css('width')` respects the `box-sizing` property when trying to figure out what width to return. 

For `box-sizing: content-box`, it will return the width of just the content.

For `box-sizing: border-box`, it will return the width of the content, padding, and border.
