### PR TITLE
Removing redundant setUnfixed() call

### DIFF
--- a/jquery-scrolltofixed.js
+++ b/jquery-scrolltofixed.js
@@ -516,9 +516,6 @@
             });
 
             target.bind('scroll.ScrollToFixed', function() {
-                target.trigger('preUnfixed.ScrollToFixed');
-                setUnfixed();
-                target.trigger('unfixed.ScrollToFixed');
                 checkScroll();
             });
 


### PR DESCRIPTION
The `setUnfixed` call in the `scroll` trigger was introduced in [this](https://github.com/bigspotteddog/ScrollToFixed/commit/ee15bc3830d861d503fd934c2a7c42325c5cee72) commit.

At the time it was probably required for some cases, but in the current code `checkScroll` calls `setUnfixed` internally in all the cases where it's required. The problem with the extra unconditional `setUnfixed` call I'm removing is that it's messing with the `position` variable when the status is already "unfixed" and the consequence is the risk of spurious scrolling of the display, for example when a fixed div is redrawn (similar to #230).